### PR TITLE
Feat(OMNI): Add Omni Airdrop

### DIFF
--- a/airdrops/icons/omni.svg
+++ b/airdrops/icons/omni.svg
@@ -1,0 +1,16 @@
+<svg width="320" height="320" viewBox="0 0 320 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="320" height="320" rx="160" fill="#0564FF"/>
+<g clip-path="url(#clip0_374_354)">
+<path d="M270.932 130.207H211.491V189.648H270.932V130.207Z" fill="white"/>
+<path d="M189.721 49L160.001 100.477L211.478 130.198L241.199 78.7204L189.721 49Z" fill="white"/>
+<path d="M108.502 189.609L78.7812 241.087L130.259 270.807L159.979 219.33L108.502 189.609Z" fill="white"/>
+<path d="M108.509 130.207H49.0679V189.648H108.509V130.207Z" fill="white"/>
+<path d="M211.492 189.656L160.015 219.377L189.736 270.854L241.213 241.134L211.492 189.656Z" fill="white"/>
+<path d="M130.275 49.0254L78.7974 78.7458L108.518 130.223L159.995 100.503L130.275 49.0254Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_374_354">
+<rect width="222" height="222" fill="white" transform="translate(49 49)"/>
+</clipPath>
+</defs>
+</svg>

--- a/airdrops/index_v1.json
+++ b/airdrops/index_v1.json
@@ -191,6 +191,23 @@
                 "chain_id": 8453,
                 "decimals": 18
             }
+        },
+        "omni": {
+            "csv_path": "airdrops/omni.csv",
+            "csv_hash": "47e07a2da379ace4aff475ab9e2e60fa870aaaaac981715a807ede30a6e1c8c3",
+            "asset_identifier": "eip155:1/erc20:0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4",
+            "url": "https://claims.omni.network/",
+            "name": "OMNI",
+            "icon": "omni.svg",
+            "icon_path": "airdrops/icons/omni.svg",
+            "new_asset_data": {
+                "asset_type": "EVM_TOKEN",
+                "address": "0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4",
+                "name": "Omni Network",
+                "symbol": "OMNI",
+                "chain_id": 1,
+                "decimals": 18
+            }
         }
     },
     "poap_airdrops": {

--- a/airdrops/index_v1.json
+++ b/airdrops/index_v1.json
@@ -194,7 +194,7 @@
         },
         "omni": {
             "csv_path": "airdrops/omni.csv",
-            "csv_hash": "47e07a2da379ace4aff475ab9e2e60fa870aaaaac981715a807ede30a6e1c8c3",
+            "csv_hash": "0e0d5520e9c18bdc4d688680deb0389e48e9a1cf7af0874696d078f6e608252d",
             "asset_identifier": "eip155:1/erc20:0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4",
             "url": "https://claims.omni.network/",
             "name": "OMNI",
@@ -202,7 +202,7 @@
             "icon_path": "airdrops/icons/omni.svg",
             "new_asset_data": {
                 "asset_type": "EVM_TOKEN",
-                "address": "0x36e66fbbce51e4cd5bd3c62b637eb411b18949d4",
+                "address": "0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4",
                 "name": "Omni Network",
                 "symbol": "OMNI",
                 "chain_id": 1,


### PR DESCRIPTION
Omni didn't publish a CSV, but they emitted an event for every elegible account. :fuelpump: :fire: 

Used the flowing script to create the CSV:
```python
import cryo
import polars as pl
from web3 import Web3

raw = cryo.collect(
    "logs",
    blocks=["19665486:19678385"],  # Contract deployment to airdrop start
    contract=["0xD0c155595929FD6bE034c3848C00DAeBC6D330F6"],  # Airdrop Contract
    topic0=[
        "0x4de45f6c76bbeb7a14efbe2f206ee9fb4e77a38116455071d1440020ff9e668d"  # RewardsSet event
    ],
    hex=True,
)

parsed = raw.with_columns(
    [
        pl.col("topic1")
        .map_elements(lambda topic: Web3.to_checksum_address("0x" + topic[26:]))
        .alias("address"),
        pl.col("data")
        .map_elements(lambda data: (int(data, 16) / (10**18)))
        .alias("amount"),
    ]
)

parsed.select(pl.col("address", "amount")).write_csv("omni.csv")
```