### PR TITLE
Fix accounting rules

### DIFF
--- a/updates/accounting_rules/v3.json
+++ b/updates/accounting_rules/v3.json
@@ -1,19 +1,6 @@
 {
     "accounting_rules": [
         {
-            "event_type": "fail",
-            "event_subtype": "fee",
-            "event_type": "spend",
-            "event_subtype": "payment",
-            "counterparty": null,
-            "taxable": true,
-            "count_entire_amount_spend": true,
-            "count_cost_basis_pnl": true,
-            "accounting_treatment": null
-        },
-        {
-            "event_type": "fail",
-            "event_subtype": "fee",
             "event_type": "spend",
             "event_subtype": "payment",
             "counterparty": null,

--- a/updates/accounting_rules/v4.json
+++ b/updates/accounting_rules/v4.json
@@ -44,6 +44,15 @@
             "count_entire_amount_spend": true,
             "count_cost_basis_pnl": true,
             "accounting_treatment": null
+        },
+        {
+            "event_type": "fail",
+            "event_subtype": "fee",
+            "counterparty": null,
+            "taxable": true,
+            "count_entire_amount_spend": true,
+            "count_cost_basis_pnl": true,
+            "accounting_treatment": null
         }
     ]
 }


### PR DESCRIPTION
We made a mistake in v3 and the first rule had in the body

```
            "event_type": "fail",
            "event_subtype": "fee",
            "event_type": "spend",
            "event_subtype": "payment",
```

since spend/payment was the last one the rule for fail/fee wasn't processed correctly. This PR moves it to v4 and removes it from v3 so users can get it correctly. ALso solves a warning about duplicate entries