### PR TITLE
Reverts duplicated entry in accounting rules

### DIFF
--- a/updates/accounting_rules/v4.json
+++ b/updates/accounting_rules/v4.json
@@ -62,24 +62,6 @@
             "count_entire_amount_spend": false,
             "count_cost_basis_pnl": true,
             "accounting_treatment": null
-        },
-        {
-            "event_type": "adjustment",
-            "event_subtype": "spend",
-            "counterparty": null,
-            "taxable": true,
-            "count_entire_amount_spend": true,
-            "count_cost_basis_pnl": true,
-            "accounting_treatment": null
-        },
-        {
-            "event_type": "adjustment",
-            "event_subtype": "receive",
-            "counterparty": null,
-            "taxable": true,
-            "count_entire_amount_spend": true,
-            "count_cost_basis_pnl": true,
-            "accounting_treatment": null
         }
     ]
 }


### PR DESCRIPTION
https://github.com/rotki/data/pull/132 introduces accounting rules for adjustments but they were already in v1 creating a conflict. The reason for them to not be detected probably is because v1 is minified and the search didn't catch them