### PR TITLE
chore: update cta for Ethereum Security QF round at Giveth

### DIFF
--- a/messages/README.md
+++ b/messages/README.md
@@ -75,3 +75,19 @@ The filename has to be `dashboard.json` and have the following schema.
 - `message_highlight` is an **optional** field. It will appear in semi-bold after the messages and before the action
 - `action` is an **optional** field. If it exists it is required to have a `text` and a `url` property. Action will appear as a link, with text being the link text and url the link that will open when clicking it.
 - `period` is a **required** field. It is the period for which the message will be displayed in the application welcome area.
+
+## Converting ISO dates to epoch timestamps
+
+The `period.start` and `period.end` fields are unix epoch timestamps (seconds). To convert an ISO 8601 date to epoch:
+
+```bash
+# GNU date (Linux)
+date -u -d "2026-04-23T15:00:00Z" +%s
+# 1776956400
+
+# BSD date (macOS)
+date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "2026-04-23T15:00:00Z" +%s
+
+# Reverse (epoch to ISO, useful for sanity-checking an existing entry)
+date -u -d "@1776956400" +"%Y-%m-%dT%H:%M:%SZ"
+```

--- a/messages/dashboard.json
+++ b/messages/dashboard.json
@@ -3,12 +3,12 @@
     "message": "Enjoying rotki? Consider",
     "message_highlight": "supporting us in",
     "action": {
-      "text": "Octant Epoch 10",
-      "url": "https://octant.app/project/10/0x9531C059098e3d194fF87FebB587aB07B30B1306"
+      "text": "Ethereum Security QF Round at Giveth",
+      "url": "https://qf.giveth.io/project/rotki?roundId=16"
     },
     "period": {
-      "start": 1767726000,
-      "end": 1768924800
+      "start": 1776956400,
+      "end": 1778835540
     }
   }
 ]

--- a/messages/welcome.json
+++ b/messages/welcome.json
@@ -3,14 +3,14 @@
     {
       "header": "Enjoying rotki?",
       "icon": "https://raw.githubusercontent.com/rotki/data/main/messages/donation.svg",
-      "text": "rotki is part of Octant Epoch 10",
+      "text": "rotki is part of the Ethereum Security QF Round at Giveth",
       "action": {
         "text": "Support us here",
-        "url": "https://octant.app/project/10/0x9531C059098e3d194fF87FebB587aB07B30B1306"
+        "url": "https://qf.giveth.io/project/rotki?roundId=16"
       },
       "period": {
-        "start": 1767726000,
-        "end": 1768924800
+        "start": 1776956400,
+        "end": 1778835540
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Update dashboard.json and welcome.json with Ethereum Security QF round at Giveth (roundId=16)
- Period: 2026-04-23T15:00:00Z → 2026-05-15T08:59:00Z
- Add ISO date → epoch conversion docs to messages/README.md

## Test plan
- [ ] Verify JSON validity
- [ ] Verify timestamps render correctly in the rotki app during the round window