### PR TITLE
Harden and pin GitHub Actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,13 +2,20 @@ name: verify
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   verify-files:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.13'
     - name: Install dependencies
@@ -16,7 +23,7 @@ jobs:
         python3 -m pip install --upgrade pip setuptools wheel
         pip3 install -r requirements.txt
     - name: Store python cache
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
## Summary
Hardens the `verify` workflow following GitHub Actions security best practices. Passes `zizmor` with no findings.

## Changes
- Pin all actions to full commit SHAs (with version comments):
  - `actions/checkout` → v7.0.0
  - `actions/setup-python` → v6.3.0
  - `actions/cache` → v6.1.0
- Set `persist-credentials: false` on checkout so the `GITHUB_TOKEN` is not left in the local git config.
- Restrict the `GITHUB_TOKEN`: top-level `permissions: {}` (deny all) with `contents: read` granted only to the job.
- Add `timeout-minutes: 15` to bound runaway jobs (recent runs finish in ~2 min).

## Verification
- `zizmor .github/workflows/verify.yml` → no findings.